### PR TITLE
Revise README with new version and AI contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your `pubspec.yaml` dependencies:
 
 ```yaml
 dependencies:
-  editorjs_flutter: ^0.5.0
+  editorjs_flutter: ^0.5.0-beta.1
 ```
 
 Then run `flutter pub get`.


### PR DESCRIPTION
This pull request updates the documentation to reference the latest beta version of the `editorjs_flutter` package in the installation instructions.

- Documentation update:
  * Updated the `pubspec.yaml` example in `README.md` to use `editorjs_flutter: ^0.5.0-beta.1` instead of `^0.5.0`.